### PR TITLE
fix: set the dbProxyName

### DIFF
--- a/src/aurora.ts
+++ b/src/aurora.ts
@@ -246,7 +246,9 @@ export class Aurora extends Construct {
 
     if (!props.skipProxy) {
       this.proxy = new aws_rds.DatabaseProxy(this, 'Proxy', {
+        dbProxyName: id.pascal,
         proxyTarget: aws_rds.ProxyTarget.fromCluster(this.cluster),
+        //requireTLS: true, // If we're never allowing connections from outside the VPC, why bother?
         secrets: this.secrets,
         vpc: props.vpc,
       });

--- a/test/aurora.test.ts
+++ b/test/aurora.test.ts
@@ -18,6 +18,9 @@ describe('Aurora', () => {
         template.resourceCountIs(r, 3),
       );
     });
+    it('proxyName', () => {
+      template.hasResourceProperties('AWS::RDS::DBProxy', { DBProxyName: 'Test' });
+    });
     it('retention', () => {
       template.hasResourceProperties('AWS::RDS::DBCluster', {
         BackupRetentionPeriod: 1,


### PR DESCRIPTION
`proxy`, the cdk default, is fine... until you have more than one proxy deploy. Then it doesn't work. So, instead, set the dbProxyName based on the ID, same as the Aurora name.

Fixes #