### PR TITLE
feat: expose optional security group prop [CLK-126702]

### DIFF
--- a/API.md
+++ b/API.md
@@ -220,6 +220,7 @@ const auroraProps: AuroraProps = { ... }
 | <code><a href="#@time-loop/cdk-aurora.AuroraProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-aurora.AuroraProps.property.retention">retention</a></code> | <code>aws-cdk-lib.Duration</code> | *No description.* |
 | <code><a href="#@time-loop/cdk-aurora.AuroraProps.property.schemas">schemas</a></code> | <code>string[]</code> | Schemas to create and grant defaults for users. |
+| <code><a href="#@time-loop/cdk-aurora.AuroraProps.property.securityGroup">securityGroup</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup</code> | Security group to use for the Aurora cluster. |
 | <code><a href="#@time-loop/cdk-aurora.AuroraProps.property.skipAddRotationMultiUser">skipAddRotationMultiUser</a></code> | <code>boolean</code> | When bootstrapping, hold off on creating the `addRotationMultiUser`. |
 | <code><a href="#@time-loop/cdk-aurora.AuroraProps.property.skipProvisionDatabase">skipProvisionDatabase</a></code> | <code>boolean</code> | Skip provisioning the database? |
 | <code><a href="#@time-loop/cdk-aurora.AuroraProps.property.skipProxy">skipProxy</a></code> | <code>boolean</code> | By default, we provide a proxy for non-manager users. |
@@ -338,6 +339,19 @@ public readonly schemas: string[];
 - *Default:* ['public']
 
 Schemas to create and grant defaults for users.
+
+---
+
+##### `securityGroup`<sup>Optional</sup> <a name="securityGroup" id="@time-loop/cdk-aurora.AuroraProps.property.securityGroup"></a>
+
+```typescript
+public readonly securityGroup: ISecurityGroup;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.ISecurityGroup
+- *Default:* create a new security group
+
+Security group to use for the Aurora cluster.
 
 ---
 

--- a/src/aurora.ts
+++ b/src/aurora.ts
@@ -61,6 +61,11 @@ export interface AuroraProps {
    */
   readonly retention?: Duration;
   /**
+   * Security group to use for the Aurora cluster.
+   * @default - create a new security group
+   */
+  readonly securityGroup?: aws_ec2.ISecurityGroup;
+  /**
    * Schemas to create and grant defaults for users.
    * @default ['public']
    */
@@ -148,10 +153,14 @@ export class Aurora extends Construct {
 
     const secretName = id.addSuffix(['manager']);
 
-    this.securityGroup = new aws_ec2.SecurityGroup(this, 'SecurityGroup', {
-      vpc: props.vpc,
-      allowAllOutbound: true,
-    });
+    if (props.securityGroup) {
+      this.securityGroup = props.securityGroup;
+    } else {
+      this.securityGroup = new aws_ec2.SecurityGroup(this, 'SecurityGroup', {
+        vpc: props.vpc,
+        allowAllOutbound: true,
+      });
+    }
 
     this.cluster = new aws_rds.DatabaseCluster(this, 'Database', {
       backup: {

--- a/test/aurora.test.ts
+++ b/test/aurora.test.ts
@@ -143,6 +143,28 @@ describe('Aurora', () => {
         BackupRetentionPeriod: 30,
       });
     });
+    it('securityGroup', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test');
+      const kmsKey = new aws_kms.Key(stack, 'Key');
+      const vpc = new aws_ec2.Vpc(stack, 'Vpc');
+      const description = 'Test security group';
+      const securityGroup = new aws_ec2.SecurityGroup(stack, 'SecurityGroup', {
+        vpc,
+        description,
+        allowAllOutbound: true,
+      });
+      new Aurora(stack, new Namer(['test']), {
+        databaseName,
+        securityGroup,
+        kmsKey,
+        vpc,
+      });
+      const template = assertions.Template.fromStack(stack);
+      template.hasResourceProperties('AWS::EC2::SecurityGroup', {
+        GroupDescription: description,
+      });
+    });
     it.todo('skipProvisionDatabase');
     it('skipAddRotationMultiUser', () => {
       const app = new App();


### PR DESCRIPTION
Allow passing in existing security group. If not specified, it'll fall back to creating a new SG for the instance. 