### PR TITLE
chore(infra): Remove pinned peerDeps from devDeps, migrate projen file to TS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,11 +37,13 @@
   },
   "ignorePatterns": [
     "*.js",
-    "!.projenrc.js",
+    "!.projenrc.ts",
     "*.d.ts",
     "node_modules/",
     "*.generated.ts",
-    "coverage"
+    "coverage",
+    "!.projenrc.ts",
+    "!projenrc/**/*.ts"
   ],
   "rules": {
     "prettier/prettier": [
@@ -55,7 +57,10 @@
       {
         "devDependencies": [
           "**/test/**",
-          "**/build-tools/**"
+          "**/build-tools/**",
+          "**/projenrc/**",
+          ".projenrc.ts",
+          "projenrc/**/*.ts"
         ],
         "optionalDependencies": false,
         "peerDependencies": true
@@ -130,7 +135,7 @@
   "overrides": [
     {
       "files": [
-        ".projenrc.js"
+        ".projenrc.ts"
       ],
       "rules": {
         "@typescript-eslint/no-require-imports": "off",

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -96,7 +96,7 @@
       "description": "Synthesize project files",
       "steps": [
         {
-          "exec": "node .projenrc.js"
+          "exec": "ts-node --project tsconfig.dev.json .projenrc.ts"
         }
       ]
     },
@@ -126,7 +126,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools .projenrc.js"
+          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern src test build-tools projenrc .projenrc.ts"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -13,7 +13,6 @@ const project = new clickupCdk.ClickUpCdkConstructLibrary({
   bundledDeps,
   deps: [...bundledDeps],
   devDeps: [
-    ...peerDeps,
     '@time-loop/clickup-projen',
     '@types/aws-lambda',
     '@types/pg',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,4 @@
-const { clickupCdk } = require('@time-loop/clickup-projen');
+import { clickupCdk } from '@time-loop/clickup-projen';
 
 const bundledDeps = ['aws-lambda', 'aws-sdk', 'aws-xray-sdk-core', 'pg', 'pg-format'];
 const peerDeps = ['constructs@^10.0.5', 'multi-convention-namer@^0.1.12'];
@@ -24,9 +24,10 @@ const project = new clickupCdk.ClickUpCdkConstructLibrary({
     'sinon-spy-utils',
   ],
   peerDeps,
+  projenrcTs: true,
 
+  author: '', // leverage default
   repositoryUrl: '', // leverage default
-  authorName: '', // leverage default
   authorAddress: '', // leverage default
 });
 project.synth();

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -27,7 +27,9 @@
   "include": [
     ".projenrc.js",
     "src/**/*.ts",
-    "test/**/*.ts"
+    "test/**/*.ts",
+    ".projenrc.ts",
+    "projenrc/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
- chore: Bump projenrc file from JS -> TS
- chore: Remove redundant devDeps which are captured in peerDeps