### PR TITLE
fix: node18 compat [CLK-274818]

### DIFF
--- a/src/aurora.ts
+++ b/src/aurora.ts
@@ -363,7 +363,10 @@ export class Aurora extends Construct {
     if (props.activityStream) {
       function activityStreamHandler(handler: string): aws_lambda_nodejs.NodejsFunction {
         const fn = new aws_lambda_nodejs.NodejsFunction(myConstruct, `ActivityStream${handler}`, {
-          bundling: { minify: true },
+          bundling: {
+            externalModules: ['aws-lambda'], // Lambda is just types
+            minify: true,
+          },
           entry: join(__dirname, 'aurora.activity-stream.ts'),
           handler,
           logRetention: props.lambdaLogRetention ?? aws_logs.RetentionDays.THREE_MONTHS,
@@ -413,7 +416,7 @@ export class Aurora extends Construct {
 
     const provisionerProps: aws_lambda_nodejs.NodejsFunctionProps = {
       bundling: {
-        externalModules: ['aws-lambda', 'aws-sdk'], // Lambda is just types. SDK is explicitly provided.
+        externalModules: ['aws-lambda'], // Lambda is just types
         minify: true,
         nodeModules: ['pg', 'pg-format'],
       },


### PR DESCRIPTION
node18 does not include aws-sdk v2 in it's base layer. We should let the cdk bundler (correctly) manage the bundling.