### PR TITLE
fix(deps): use writer and readers instead [CLK-272228]

### DIFF
--- a/API.md
+++ b/API.md
@@ -609,7 +609,7 @@ public readonly instances: number;
 ```
 
 - *Type:* number
-- *Default:* passthrough
+- *Default:* 2 one for writer and one for reader
 
 How many instances?
 


### PR DESCRIPTION
## what
https://staging.clickup.com/t/333/CLK-272228

follow this aws migration doc: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_rds-readme.html#migrating-from-instanceprops

## test
`npx progen test` and deprecation warning is gone.

@ahammond please advise other test steps needed.

